### PR TITLE
Added support to user names with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ exports.decorateConfig = config => {
 			css: `
         ${config.css || ''}
         .terms_terms {
-          background: url(file://${pathToTheme}) center;
+          background: url("file://${pathToTheme}") center;
           background-size: cover;
         }
         .header_header, .header_windowHeader {


### PR DESCRIPTION
Image path was not wrapped in double quotes causing a failure when trying to retrieve the backgrounds in environments where the user have a space in the user name or the installation path.

<!--

Thank you for taking the time to contribute to Hyper Star Wars! ✨🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/hyper-pokemon/hyper-star-wars/blob/master/contributing.md).

We are always excited about pull requests! If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`. Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage!
Thank you so much again for all of your time invested in the project! 🙌 ❤️

-->
