### PR TITLE
Apply 'unibody' color as Hyper main window background

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function getUserOptions({StarWarsTheme: config = {}}) {
       if (Array.isArray(config.character)) {
         return config.character[Math.floor(Math.random() * config.character.length)];
       }
+
       return config.character || 'yoda';
     },
     get lightsaber() {
@@ -53,14 +54,17 @@ function getThemeColors(theme) {
   if (name === 'random') {
     return getRandomTheme(themes.characters);
   }
+
   if (Object.prototype.hasOwnProperty.call(themes, name)) {
     // Choose a random theme from the given category -- i.e. `light`
     return getRandomTheme(themes[name]);
   }
+
   if (Object.prototype.hasOwnProperty.call(themes.characters, name)) {
     // Return the requested character theme -- i.e. `bb8`
     return [name, themes.characters[name]];
   }
+
   // Got non-existent theme name thus resolve to default
   return ['yoda', themes.characters.yoda];
 }
@@ -71,6 +75,7 @@ function getImagePath(character) {
   if (process.platform === 'win32') {
     return imagePath.join('').replace(/\\/g, '/');
   }
+
   return imagePath.join('');
 }
 

--- a/index.js
+++ b/index.js
@@ -133,6 +133,9 @@ exports.decorateConfig = config => {
     `,
     css: `
       ${config.css || ''}
+      .hyper_main {
+        background-color: ${unibodyColor};
+      }
       .terms_terms {
         background: ${backgroundContent};
         background-size: cover;


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Hyper Star Wars! ✨🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/hyper-star-wars/blob/master/contributing.md).

We are always excited about pull requests.
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

Thank you so much again for all of your time invested in the project! 🙌 ❤️

-->

Apply `unibody` color as `background-color` to the whole Hyper window to avoid issues when other plugins add margin around `terms`.
(see https://github.com/panz3r/hyper-spotify/issues/28 for an example)